### PR TITLE
Change license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,19 @@
-Copyright 2011, Jacques Fortier. All rights reserved.
+Copyright 2011, Jacques Fortier
 
-Redistribution and use in source and binary forms are permitted, with or without modification.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cobs.c
+++ b/cobs.c
@@ -1,7 +1,9 @@
-/* Copyright 2011, Jacques Fortier. All rights reserved.
+/*
+ * Copyright (c) 2011 Jacques Fortier
  *
- * Redistribution and use in source and binary forms are permitted, with or without modification.
+ * SPDX-License-Identifier: MIT
  */
+
 #include <stdint.h>
 #include <stddef.h>
 

--- a/cobs.h
+++ b/cobs.h
@@ -1,7 +1,9 @@
-/* Copyright 2011, Jacques Fortier. All rights reserved.
+/*
+ * Copyright (c) 2011 Jacques Fortier
  *
- * Redistribution and use in source and binary forms are permitted, with or without modification.
+ * SPDX-License-Identifier: MIT
  */
+
 #ifndef COBS_H
 #define COBS_H
 

--- a/cobs_test.c
+++ b/cobs_test.c
@@ -1,7 +1,9 @@
-/* Copyright 2011, Jacques Fortier. All rights reserved.
+/*
+ * Copyright (c) 2011 Jacques Fortier
  *
- * Redistribution and use in source and binary forms are permitted, with or without modification.
+ * SPDX-License-Identifier: MIT
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>


### PR DESCRIPTION
Hi Jacques,

as discussed via eMail the change to MIT license so that we can use our fork as a dependency with Zephyr.

Cheers,
Steffen